### PR TITLE
AlimTleuliyev/3rd Degree Poly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Thumbs.db # Windows specific
 
 # Visualization outputs
 **/*.png
+**/figures/

--- a/notebooks/experiment.ipynb
+++ b/notebooks/experiment.ipynb
@@ -120,20 +120,28 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "9",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "fitted_gs = train(\"poly_elastic\", X_train, y_train, random_state=SEED)\n",
-    "test_results = eval(fitted_gs, X_test, y_test)"
+    "#### 2nd degree"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitted_gs = train(\"poly_elastic_2\", X_train, y_train, random_state=SEED)\n",
+    "test_results = eval(fitted_gs, X_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,16 +156,60 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_results(\"poly_elastic\", test_results)"
+    "plot_results(\"poly_elastic_2\", test_results)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "#### 3rd degree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitted_gs = train(\"poly_elastic_3\", X_train, y_train, random_state=SEED)\n",
+    "test_results = eval(fitted_gs, X_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Best alpha: {test_results['estimator'].alpha}\")\n",
+    "print(f\"Best L1 ratio: {test_results['estimator'].l1_ratio}\")\n",
+    "print(\"=\" * 30)\n",
+    "print(f\"RMSE: {test_results['rmse']:.2f}\")\n",
+    "print(f\"MAE: {test_results['mae']:.2f}\")\n",
+    "print(f\"R2: {test_results['r2']:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_results(\"poly_elastic_3\", test_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
    "metadata": {},
    "source": [
     "### kNN"
@@ -166,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/housing.py
+++ b/src/housing.py
@@ -17,15 +17,27 @@ BASE_PIPELINE = [
     ("scaler", StandardScaler()),
 ]
 
+LINEAR_GRID = {
+    "model__alpha": [0.001, 0.01, 0.1, 1.0, 10.0],
+    "model__l1_ratio": [0.0, 0.5, 1.0],
+}
+
 MODELS = {
     "simple_elastic": {
         "pipeline": Pipeline(BASE_PIPELINE + [("model", ElasticNet(max_iter=1000))]),
-        "param_grid": {
-            "model__alpha": [0.001, 0.01, 0.1, 1.0, 10.0],
-            "model__l1_ratio": [0.0, 0.5, 1.0],
-        },
+        "param_grid": LINEAR_GRID,
     },
-    "poly_elastic": {
+    "poly_elastic_3": {
+        "pipeline": Pipeline(
+            BASE_PIPELINE
+            + [
+                ("poly", PolynomialFeatures(degree=3, include_bias=False)),
+                ("model", ElasticNet(max_iter=1000)),
+            ]
+        ),
+        "param_grid": LINEAR_GRID,
+    },
+    "poly_elastic_2": {
         "pipeline": Pipeline(
             BASE_PIPELINE
             + [
@@ -33,10 +45,7 @@ MODELS = {
                 ("model", ElasticNet(max_iter=1000)),
             ]
         ),
-        "param_grid": {
-            "model__alpha": [0.001, 0.01, 0.1, 1.0, 10.0],
-            "model__l1_ratio": [0.0, 0.5, 1.0],
-        },
+        "param_grid": LINEAR_GRID,
     },
     "knn": {
         "pipeline": Pipeline(BASE_PIPELINE + [("model", KNeighborsRegressor())]),


### PR DESCRIPTION
This pull request updates the polynomial regression experiments in the `notebooks/experiment.ipynb` notebook and refactors the model configuration in `src/housing.py` to improve clarity and flexibility. The main changes include adding explicit 2nd and 3rd degree polynomial regression experiments, introducing a shared hyperparameter grid, and renaming model identifiers for consistency.

**Polynomial Regression Experiment Enhancements:**

* Added separate sections and code cells for 2nd (`poly_elastic_2`) and 3rd (`poly_elastic_3`) degree polynomial regression experiments in the notebook, with corresponding evaluation and plotting steps.

**Model Configuration Refactoring:**

* Introduced a shared `LINEAR_GRID` hyperparameter grid to avoid duplication in model definitions.
* Added a new model entry for 3rd degree polynomial regression (`poly_elastic_3`) and renamed the 2nd degree model from `poly_elastic` to `poly_elastic_2` for clarity and consistency.